### PR TITLE
Don't throw an exception when Array has been monkeypatched

### DIFF
--- a/youtube-feeds.js
+++ b/youtube-feeds.js
@@ -223,9 +223,9 @@ app.talk = function( path, fields, cb, oldJsonKey ) {
 			var buf = new Buffer( size )
 			var pos = 0
 			
-			for( var d in data ) {
-				data[d].copy( buf, pos )
-				pos += data[d].length
+			for( var i = 0; i < data.length; ++i ) {
+				data[i].copy( buf, pos )
+				pos += data[i].length
 			}
 			
 			data = buf.toString('utf8').trim()


### PR DESCRIPTION
The simple reproduction case is:
`Array.prototype.noop = function() {}
require('./youtube-feeds').feeds.videos({q: 'test'}, console.log);`

This is a really big problem because a lot of modules monkeypatch Array and these other modules will break this one. It makes it practically unusable in any large projects.
